### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8


### PR DESCRIPTION
Editor config is a IDE agnostic config file. 

A lot of editors will honour it meaning people can develop in an IDE of their choice, but still be conformant to the coding standard of the project.

This config will only take affect when this repository is open in the editor, meaning it only temporarily overrides the editor settings to these values, so it won't be changing settings people like for longer than needed/permanently. 

Personally I've seen it be honoured by vscode and neovim.

It looks like it's also supported by JetBrains: https://plugins.jetbrains.com/plugin/7294-editorconfig